### PR TITLE
Fix issue for ROS Dashing

### DIFF
--- a/src/ydlidar_node.cpp
+++ b/src/ydlidar_node.cpp
@@ -75,35 +75,49 @@ int main(int argc, char *argv[]) {
   double min_range = 0.06;
   double frequency = 7.0;
 
-
+  node->declare_parameter("port");
   node->get_parameter("port", port);
 
+  node->declare_parameter("frame_id");
   node->get_parameter("frame_id", frame_id);
 
+  node->declare_parameter("ignore_array");
   node->get_parameter("ignore_array", list);
 
+  node->declare_parameter("baudrate");
   node->get_parameter("baudrate", baudrate);
 
+  node->declare_parameter("samp_rate");
   node->get_parameter("samp_rate", samp_rate);
 
+  node->declare_parameter("resolution_fixed");
   node->get_parameter("resolution_fixed", resolution_fixed);
 
+  node->declare_parameter("low_exposure");
   node->get_parameter("low_exposure", low_exposure);
 
+  node->declare_parameter("auto_reconnect");
   node->get_parameter("auto_reconnect", auto_reconnect);
 
+  node->declare_parameter("reversion");
   node->get_parameter("reversion", reversion);
 
+  node->declare_parameter("intensities");
   node->get_parameter("intensities", intensities);
 
+  node->declare_parameter("angle_max");
   node->get_parameter("angle_max", angle_max);
 
+  node->declare_parameter("angle_min");
   node->get_parameter("angle_min", angle_min);
 
+  node->declare_parameter("max_range");
   node->get_parameter("max_range", max_range);
 
+  node->declare_parameter("min_range");
   node->get_parameter("min_range", min_range);
 
+  node->declare_parameter("frequency");
   node->get_parameter("frequency", frequency);
 
 


### PR DESCRIPTION
Since ROS Dashing a parameter must be decared before you can get it.
I've tested this with ROS2 Dashing, but not with the older versions

See documentation here: https://index.ros.org//doc/ros2/Releases/Release-Dashing-Diademata/#getting-and-setting-undeclared-parameters